### PR TITLE
Feat/persist on terminate

### DIFF
--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -208,7 +208,7 @@ defmodule RingLogger.Server do
     {:noreply, detach_client(pid, state)}
   end
 
-  def handle_info(:tick, state = %__MODULE__{perist_path: path}) when is_binary(path) do
+  def handle_info(:tick, state = %__MODULE__{persist_path: path}) when is_binary(path) do
     Process.send_after(self(), :tick, state.persist_seconds * 1000)
 
     case Persistence.save(state.persist_path, merge_buffers(state)) do

--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -208,7 +208,7 @@ defmodule RingLogger.Server do
     {:noreply, detach_client(pid, state)}
   end
 
-  def handle_info(:tick, state) do
+  def handle_info(:tick, state = %__MODULE__{perist_path: path}) when is_binary(path) do
     Process.send_after(self(), :tick, state.persist_seconds * 1000)
 
     case Persistence.save(state.persist_path, merge_buffers(state)) do
@@ -222,10 +222,24 @@ defmodule RingLogger.Server do
     end
   end
 
+  def handle_info(:tick, state = %__MODULE__{persist_path: path}) do
+    Logger.warning("RingLogger attempt to persisting log when the path (#{path}) is invalid")
+  end
+
   @impl GenServer
-  def terminate(_reason, state) do
-    Enum.each(state.clients, fn {client_pid, _ref} -> Client.stop(client_pid) end)
+  def terminate(_reason, state = %__MODULE__{persist_path: path}) when is_binary(path) do
+    Persistence.save(state.persist_path, merge_buffers(state))
+    close_all_clients(state)
     :ok
+  end
+
+  def terminate(_reason, state) do
+    close_all_clients(state)
+    :ok
+  end
+
+  defp close_all_clients(state) do
+    Enum.each(state.clients, fn {client_pid, _ref} -> Client.stop(client_pid) end)
   end
 
   defp adjust_left({offset, n}, i) when i > offset do


### PR DESCRIPTION
[FAQM-1229 Update RingLogger to save on terminate if persistence is configured](https://fellowesbrands.atlassian.net/browse/FAQM-1229)

It was assumed, RingLogger would save the logs on termination if persistence was enabled. This assumption turns out to have been wrong. This ticket is to change the behavior to match the assumption.
Persist the logs on terminate if persistence is enabled. So logs are not lost to a Nerves.Runtime.reboot.
This is part of the V4 troubleshooting. Especially the boot loop which starts Nerves then reboots but there are no Nerves logs. This may or may not help depending on how the reboot is happening.

Related to: https://github.com/FellowesInc/blofeld_iot_firmware/pull/213