### PR TITLE
FAQM-4054: Restore full log level fidelity via :erl_level metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 * Changes
+  * Restore full log level fidelity: entries now keep their original `:notice`,
+    `:critical`, `:alert`, and `:emergency` levels instead of being collapsed
+    to `:info`/`:error`. The Logger backend translation layer only delivers the
+    legacy four backend levels but preserves the original level in `:erl_level`
+    metadata, which RingLogger now prefers. This also makes the viewer's level
+    filter usable for all eight levels, and adds `:emergency`, `:alert`,
+    `:critical`, and `:notice` color options (defaulting to the `:error` and
+    `:info` colors, matching `LoggerBackends.Console`).
   * Normalize the deprecated `:warn` log level to `:warning` when storing log
     entries, loading persisted logs, and reading configuration. The
     `logger_backends` translation layer still delivers warnings to backends as

--- a/lib/ring_logger/client.ex
+++ b/lib/ring_logger/client.ex
@@ -415,14 +415,20 @@ defmodule RingLogger.Client do
   defp configure_metadata(metadata), do: Enum.reverse(metadata)
 
   defp configure_colors(colors) when is_list(colors) do
+    error_color = Keyword.get(colors, :error, :red)
+    info_color = Keyword.get(colors, :info, :normal)
     warning_color = Keyword.get(colors, :warning, Keyword.get(colors, :warn, :yellow))
 
     %{
-      debug: Keyword.get(colors, :debug, :cyan),
-      info: Keyword.get(colors, :info, :normal),
+      emergency: Keyword.get(colors, :emergency, error_color),
+      alert: Keyword.get(colors, :alert, error_color),
+      critical: Keyword.get(colors, :critical, error_color),
+      error: error_color,
       warn: warning_color,
       warning: warning_color,
-      error: Keyword.get(colors, :error, :red),
+      notice: Keyword.get(colors, :notice, info_color),
+      info: info_color,
+      debug: Keyword.get(colors, :debug, :cyan),
       enabled: Keyword.get(colors, :enabled, IO.ANSI.enabled?())
     }
   end

--- a/lib/ring_logger/server.ex
+++ b/lib/ring_logger/server.ex
@@ -286,7 +286,7 @@ defmodule RingLogger.Server do
     index = state.index
 
     log_entry = %{
-      level: normalize_level(level),
+      level: entry_level(level, metadata),
       module: module,
       message: message,
       timestamp: timestamp,
@@ -377,6 +377,15 @@ defmodule RingLogger.Server do
       {:error, _reason} ->
         state
     end
+  end
+
+  # The Logger backend translation layer (core Elixir through 1.14,
+  # logger_backends afterwards) collapses erlang levels onto the legacy four
+  # backend levels (:debug/:info/:warn/:error) but preserves the original in
+  # :erl_level metadata. Prefer it so :notice, :critical, :alert, and
+  # :emergency entries keep their real level.
+  defp entry_level(level, metadata) do
+    metadata |> Keyword.get(:erl_level, level) |> normalize_level()
   end
 
   # Elixir's Logger deprecated :warn in favor of :warning, but the

--- a/test/ring_logger/client_test.exs
+++ b/test/ring_logger/client_test.exs
@@ -37,8 +37,19 @@ defmodule RingLogger.Client.Test do
 
       Client.configure(client, colors: colors)
 
-      # The legacy :warn color is used for both :warn and :warning entries
-      assert Map.put(colors, :warning, :cyan) == :sys.get_state(client).colors
+      # The legacy :warn color is used for both :warn and :warning entries;
+      # emergency/alert/critical default to the :error color and notice to
+      # the :info color
+      expected =
+        Map.merge(colors, %{
+          warning: :cyan,
+          emergency: :yellow,
+          alert: :yellow,
+          critical: :yellow,
+          notice: :normal
+        })
+
+      assert expected == :sys.get_state(client).colors
     end
 
     test "configure colors with a :warning key", %{client: client} do
@@ -47,6 +58,17 @@ defmodule RingLogger.Client.Test do
       colors = :sys.get_state(client).colors
       assert colors.warning == :magenta
       assert colors.warn == :magenta
+    end
+
+    test "configure colors for erlang-only levels", %{client: client} do
+      Client.configure(client, colors: %{critical: :magenta, notice: :light_blue})
+
+      colors = :sys.get_state(client).colors
+      assert colors.critical == :magenta
+      assert colors.notice == :light_blue
+      # Unspecified erlang levels still follow the :error color default
+      assert colors.emergency == :red
+      assert colors.alert == :red
     end
 
     test "configure metadata", %{client: client} do
@@ -108,10 +130,14 @@ defmodule RingLogger.Client.Test do
   test "can retrieve configuration", %{client: client} do
     config = [
       colors: %{
+        alert: :red,
+        critical: :red,
         debug: :cyan,
+        emergency: :red,
         enabled: true,
         error: :red,
         info: :normal,
+        notice: :normal,
         warn: :yellow,
         warning: :yellow
       },

--- a/test/ring_logger_test.exs
+++ b/test/ring_logger_test.exs
@@ -326,6 +326,31 @@ defmodule RingLoggerTest do
     assert [%{level: :warning, module: Logger, message: "legacy warn"}] = buffer
   end
 
+  test "entries keep their original level from :erl_level metadata", %{io: io} do
+    :ok = RingLogger.attach(io: io)
+
+    # The backend translation layer collapses :notice to :info and :critical
+    # to :error, but preserves the original level in :erl_level metadata
+    timestamp = {{2023, 2, 8}, {13, 58, 31, 343}}
+    RingLogger.Server.log(:info, {Logger, "a notice", timestamp, [erl_level: :notice]})
+    RingLogger.Server.log(:error, {Logger, "a critical", timestamp, [erl_level: :critical]})
+
+    buffer = RingLogger.get()
+
+    assert [
+             %{level: :notice, message: "a notice"},
+             %{level: :critical, message: "a critical"}
+           ] = buffer
+  end
+
+  test "erlang-only levels survive the whole logging pipeline", %{io: io} do
+    :ok = RingLogger.attach(io: io)
+    handshake_log(io, :notice, "Attention")
+
+    buffer = RingLogger.get()
+    assert [%{level: :notice, module: Logger, message: "Attention"}] = buffer
+  end
+
   test "buffer does not exceed size", %{io: io} do
     Logger.configure_backend(RingLogger, max_size: 2)
     :ok = RingLogger.attach(io: io)
@@ -610,10 +635,14 @@ defmodule RingLoggerTest do
 
       config = [
         colors: %{
+          alert: :red,
+          critical: :red,
           debug: :cyan,
+          emergency: :red,
           enabled: true,
           error: :red,
           info: :normal,
+          notice: :normal,
           warn: :yellow,
           warning: :yellow
         },


### PR DESCRIPTION
Stacked on #9 — that lands first, this is one commit on top.

The Logger backend translation layer (core Elixir through 1.14, `logger_backends` after) collapses erlang levels onto the legacy four backend levels: `:notice` -> `:info`, `:critical`/`:alert`/`:emergency` -> `:error` ([handler.ex:115-124](https://github.com/elixir-lang/logger_backends/blob/v1.0.1/lib/logger_backends/handler.ex#L115-L124)). So those levels never made it into the buffer, even though the viewer's `@level_strings` already lists all eight and `format_level/1` already knows how to render each one — filtering by `notice` in the viewer could never match anything.

The original level survives in `:erl_level` metadata (present since Elixir 1.13, ring_logger's minimum). `LoggerBackends.Console` recovers it the same way ([console.ex:97](https://github.com/elixir-lang/logger_backends/blob/v1.0.1/lib/logger_backends/console.ex#L97)), so this follows the same pattern rather than inventing a new one.

**Fix:** server ingest prefers `metadata[:erl_level]` over the delivered level. Client colors map gets `:emergency`/`:alert`/`:critical`/`:notice` keys, defaulting to the `:error`/`:info` colors like Console does.

Visible behavior change: entries at erlang-only levels now display their real level (`[notice]` instead of `[info]`). Keeping this fork-only for now since it's a behavior change, not a deprecation fix — can offer it upstream once #239 lands.

FAQM-4054

**Tested:**
- New tests: `:erl_level` preserved at ingest, an actual `Logger.log(:notice, ...)` through the real backend pipeline, colors config for the new levels
- `mix test --warnings-as-errors` (92 tests), `mix format --check-formatted`, `mix credo -a --strict`, `mix dialyzer` all pass
- Verified against blofeld_iot_firmware on host: buffer now shows `%{warning: 1, notice: 1, critical: 1}` for a `Logger.notice/critical/warning` repro, no deprecation warnings. `mix test`: 562 passed, 7 skipped.